### PR TITLE
Add  url parameter to filer-file.js open file method in order to…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Features
 ========
 
  * Django form fields to integrate the bootstrap markdown editor (without the dependency on bootstrap)
- * `django-filer <https://github.com/stefanfoulis/django-filer>`_ integration
+ * `django-filer <https://github.com/divio/django-filer>`_ integration
  * `django-anylink <https://github.com/moccu/django-anylink>`_ integration
  * Various extensions to provide `GitHub Flavored Markdown <https://help.github.com/articles/github-flavored-markdown/>`_
 

--- a/markymark/static/markdown/js/plugins/filer-file.js
+++ b/markymark/static/markdown/js/plugins/filer-file.js
@@ -71,7 +71,7 @@
 					.addClass('has-image');
 			};
 
-			window.open('/admin/filer/folder/?_popup=1', 'Filer', 'width=800,height=600');
+			window.open('/admin/filer/folder/?_popup=1&_pick=file', 'Filer', 'width=800,height=600');
 		},
 
 		onClick: function(e) {

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ test_requirements = [
     'cov-core==1.15.0',
     'mock==1.3.0',
     'factory-boy==2.5.2',
-    'django-filer==1.1.1',
+    'django-filer==1.2.4',
     'django-anylink==0.3.0',
 ]
 
@@ -64,7 +64,7 @@ setup(
     install_requires=install_requirements,
     extras_require={
         'tests': test_requirements,
-        'filer': ['django-filer', ],
+        'filer': ['django-filer==1.2.4', ],
         'anylink': ['django-anylink', ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     install_requires=install_requirements,
     extras_require={
         'tests': test_requirements,
-        'filer': ['django-filer==1.2.4', ],
+        'filer': ['django-filer>=1.2.0,<1.3.0', ],
         'anylink': ['django-anylink', ],
     },
     include_package_data=True,


### PR DESCRIPTION
… support django-filer 1.2.x. Pin django-filer version requirement to current version, 1.2.4

django-filter 1.2.x uses the `_pick` URL param to enable selection of files or folders in a popup. Adding `_pick=file` to the URL in filer-file.js makes django-markymark compatible with the current version [django-filer](https://github.com/divio/django-filer).