### PR TITLE
Fix MarkdownField ability to use widget instances & set install_requirements based on python version

### DIFF
--- a/markymark/fields.py
+++ b/markymark/fields.py
@@ -6,9 +6,14 @@ from .widgets import MarkdownTextarea
 
 class MarkdownFormField(forms.fields.CharField):
     def __init__(self, *args, **kwargs):
-        widget = kwargs.get('widget', None)
-        if not widget or not issubclass(widget, MarkdownTextarea):
-            kwargs['widget'] = MarkdownTextarea
+        widget = kwargs.get('widget', MarkdownTextarea)
+        try:
+            if not issubclass(widget, MarkdownTextarea):
+                widget = MarkdownTextarea
+        except TypeError:
+            if not isinstance(widget, MarkdownTextarea):
+                widget = MarkdownTextarea
+        kwargs['widget'] = widget
         super(MarkdownFormField, self).__init__(*args, **kwargs)
 
 

--- a/markymark/tests/test_fields.py
+++ b/markymark/tests/test_fields.py
@@ -18,3 +18,13 @@ def test_markdownfield_formfield_no_override():
     form_field = field.formfield(widget=CustomMarkdownTextarea)
     assert isinstance(form_field, MarkdownFormField)
     assert isinstance(form_field.widget, CustomMarkdownTextarea)
+
+
+def test_markdownfield_widget_instance():
+    field = MarkdownField()
+    widget_instance = MarkdownTextarea(attrs={'rows': 30, 'autofocus': True})
+    form_field = field.formfield(widget=widget_instance)
+    assert isinstance(form_field, MarkdownFormField)
+    assert isinstance(form_field.widget, MarkdownTextarea)
+    assert form_field.widget.attrs['rows'] == 30
+    assert form_field.widget.attrs['autofocus'] is True

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,15 @@ def read(*parts):
 
 
 install_requirements = [
-    'django>=1.6',
-    'markdown-py26-support==2.6.2'
+    'django>=1.7',
+    'Markdown>=2.6,<2.7',
 ]
+
+if sys.version_info < (2, 7):
+    install_requirements = [
+        'django<1.7',  # 1.6.x is last version to support py26
+        'markdown-py26-support==2.6.2',
+    ]
 
 
 test_requirements = [


### PR DESCRIPTION
b200956cb9c7063d1fdb2cc4767626e0436b566f closes #7.

f11439fd59b3d08e252ce1f5e88b42ff9df0c60a sets install_requirements differently for python versions 2.7 and above. I made these changes so newer versions of python can use the 'official' Markdown library, which may get installed anyway if third-party markdown extensions are also installed. For example, `pip install MarkdownSuperscript` triggers install of `Markdown` in py35, which means both `Markdown` and  `markdown-py26-support` can end up in site-packages.

When the active python is py26, the original requirement of `markdown-py26-support` is used and Django is limited to <1.7 since the 1.6.x series is the last to support py26.