### PR TITLE
Render rel="noreferrer noopener" when target="_blank"

### DIFF
--- a/markymark/templates/markymark/anylink.html
+++ b/markymark/templates/markymark/anylink.html
@@ -1,1 +1,1 @@
-<a href="{{ link.get_absolute_url }}" title="{{ link.title }}" target="{{ link.target }}">{{ link.text }}</a>
+<a href="{{ link.get_absolute_url }}" title="{{ link.title }}" target="{{ link.target }}"{% if link.target|lower == '_blank' %} rel="noreferrer noopener"{% endif %}>{{ link.text }}</a>

--- a/tests/test_markdown_extensions.py
+++ b/tests/test_markdown_extensions.py
@@ -68,6 +68,15 @@ class TestAnylinkExtension:
             self.link.external_url)
         assert expected == markdown_filter('[link:{0}]'.format(self.link.pk))
 
+    def test_file_render_target_success(self):
+        self.link.target = '_blank'
+        self.link.save()
+        expected = (
+            '<p><a href="{0}" title="" target="_blank" '
+            'rel="noreferrer noopener"></a></p>'
+        ).format(self.link.external_url)
+        assert expected == markdown_filter('[link:{0}]'.format(self.link.pk))
+
 
 class TestAutoLinkExtension:
 


### PR DESCRIPTION
# Links to cross-origin destinations are unsafe 

(See: [https://developers.google.com/web/tools/lighthouse/audits/noopener](https://developers.google.com/web/tools/lighthouse/audits/noopener))

## Performance

When you open another page using target="_blank", the other page may run on the same process as your page, unless Site Isolation is enabled. If the other page is running a lot of JavaScript, your page's performance may also suffer.

## Security

The other page can access your window object with the window.opener property. This exposes an attack surface because the other page can potentially redirect your page to a malicious URL.

## Fix

This fixes the described behaviour inside the anylink extension.